### PR TITLE
Added: Support for null properties, undefined properties are discarded

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -1,49 +1,59 @@
-
 /**
  * Build Schema for nimnification of JSON data
- * @param {*} jsObj 
+ * @param {*} jsObj
  */
-function buildSchema(jsObj,key){
-    var type = typeOf(jsObj);
-    switch(type){
-        case "array":
-            var schema = {
-                type : 'list',
-                detail : buildSchema(jsObj[0])
-            };
-            key && ( schema.name = key)
-            return schema;
-        case "object":
-            var schema = {  
-                type : 'map',
-                detail : []
-            };
-            key && ( schema.name = key);
-            var keys = Object.keys(jsObj);
-            for(var i in keys){
-                var key = keys[i];
-                schema.detail.push( buildSchema(jsObj[key], key) );
-            }
-            return schema;
-        case "string":
-        case "number":
-        case "date":
-        case "boolean":
-            var schema = {
-                type : type,
-            };
-            key && ( schema.name = key)
-            return schema;
-        default:
-            throw Error("Unacceptable type : " + type);
-    }
+function buildSchema(jsObj, key) {
+  if (jsObj === undefined) return null;
+
+  var type = typeOf(jsObj);
+  switch (type) {
+    case "array":
+      {
+        let schema = {
+          type: "list",
+          detail: buildSchema(jsObj[0])
+        };
+        key && (schema.name = key);
+        return schema;
+      }
+    case "object":
+      {
+        let schema = {
+          type: "map",
+          detail: []
+        };
+        key && (schema.name = key);
+        let keys = Object.keys(jsObj);
+        for (var i in keys) {
+          let key = keys[i];
+          if (jsObj[key] !== undefined) {
+            schema.detail.push(buildSchema(jsObj[key], key));
+          }
+        }
+        return schema;
+      }
+    case "null":
+    case "string":
+    case "number":
+    case "date":
+    case "boolean":
+      {
+        let schema = {
+          type: type
+        };
+        key && (schema.name = key);
+        return schema;
+      }
+    default:
+      throw Error("Unacceptable type : " + type);
+  }
 }
 
-function typeOf(obj){
-    if(obj === null) return "null";
-    else if(Array.isArray(obj)) return "array";
-    else if(obj instanceof Date) return "date";
-    else return typeof obj;
+function typeOf(obj) {
+  if (obj === null) return "null";
+  else if (Array.isArray(obj)) return "array";
+  else if (obj instanceof Date) return "date";
+  else return typeof obj;
 }
 
 module.exports.build = buildSchema;


### PR DESCRIPTION
# PR Reason:

Current build for nimnjs-schema-builder does not support properties that are either null or undefined. To make datasets that contain null/undefined properties work, I am proposing the following changes.

## Proposed Changes

1. Object properties that are undefined will not be parsed. This works similar to JSON.stringify.
2. Null properties will be parsed as a valid schema. 
3. Undefined object should return null as the base case.

## Additional _changes_

1. Reformated code
